### PR TITLE
Customize profiles home #11

### DIFF
--- a/bagger-business/src/main/java/gov/loc/repository/bagger/domain/JSonBagger.java
+++ b/bagger-business/src/main/java/gov/loc/repository/bagger/domain/JSonBagger.java
@@ -30,11 +30,15 @@ public class JSonBagger implements Bagger {
 
   private File profilesFolder;
   
+  private static final String BAGGER_PROFILES_HOME_PROPERTY = "BAGGER_PROFILES_HOME";
   private static final String RESOURCE_DIR = "gov/loc/repository/bagger/profiles";
   private static final String[] DEFAULT_PROFILES = new String[]{"eDeposit-profile.json", "ndiipp-profile.json", "ndnp-profile.json", "other-project-profile.json"};
 
   public JSonBagger() {
     String homeDir = System.getProperty("user.home");
+    if(System.getProperties().containsKey(BAGGER_PROFILES_HOME_PROPERTY)){
+      homeDir = System.getProperty(BAGGER_PROFILES_HOME_PROPERTY);
+    }
     String profilesPath = homeDir + File.separator + "bagger";
     profilesFolder = new File(profilesPath);
     String baggerJarPath = this.getClass().getProtectionDomain().getCodeSource().getLocation().getPath();

--- a/bagger/build.gradle
+++ b/bagger/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "de.undercouch.download" version "1.2"
+  id "de.undercouch.download" version "2.0.0"
 }
 
 apply plugin: "application"


### PR DESCRIPTION
closes #11 - customize profile locations/enable profiles across all users

Now the profile loader will look for the system property `BAGGER_PROFILES_HOME` and if it exists will use that instead of the user's home directory.
This can be set using environment variable BAGGER_OPTS like this in bash:
`export BAGGER_OPTS="-DBAGGER_PROFILES_HOME=/tmp"`