### PR TITLE
Header fixes and minor formatting improvements for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 #Bagger
 [![License](https://img.shields.io/badge/License-Public--Domain-blue.svg)](https://github.com/LibraryOfCongress/bagger/blob/master/LICENSE.txt)
 
-##Introduction
+## Introduction
 The Bagger application was created for the U.S. Library of Congress as a tool to produce a package of data files according to the BagIt specification (http://tools.ietf.org/html/draft-kunze-bagit).
 
 The Bagger application is a graphical user interface to the BagIt specification. The latest Bagger release is available on GitHub at https://github.com/LibraryOfCongress/bagger/releases/latest
@@ -16,32 +16,32 @@ These project profiles can be edited manually and shared with other users.
 3. To contact a developer at the Library of Congress please email repo-dev@listserv.loc.gov
 4. If you would like to contribute, please submit a [pull request](https://help.github.com/articles/creating-a-pull-request/)
 
-##Installing
+## Installing
 1. Install Java from https://java.com
 2. Download the latest release from https://github.com/LibraryOfCongress/bagger/releases/latest
 3. Unzip to a location. This will be known as \<BAGGER_INSTALL_DIRECTORY> for the rest of the instructions
 
-##Running Bagger on Windows
-1. navigate to \<BAGGER_INSTALL_DIRECTORY>\\bin
+## Running Bagger on Windows
+1. navigate to `<BAGGER_INSTALL_DIRECTORY>\\bin`
 2. double-click on the bagger.bat file
 
-##Running Bagger in Mac OS X/Linux/Ubuntu
-1. Navigate to \<BAGGER_INSTALL_DIRECTORY>/bin
+## Running Bagger in Mac OS X/Linux/Ubuntu
+1. Navigate to `<BAGGER_INSTALL_DIRECTORY>/bin`
 2. double-click the file named bagger
 
-##License
+## License
 License and other related information are listed in the LICENSE.txt file included with Bagger.
 
-###Project Profile
+### Project Profile
 Bag metadata is stored in a 'bag-info.txt' file, as defined in the BagIt specification.  When using Bagger to manage bags for a project or collection, it can be helpful to have a template of bag-info.txt fields and values that are filled out similarly for each bag in that project or collection.
-Profiles let users define a collection of bag metadata fields and default field values to be used with each bag in a consistent way. 
-Users can select a project profile when creating a bag, and that profile will determine the initial fields and values in the bag-info.txt file, and the profile used is identified by the "Profile Name" field. 
+Profiles let users define a collection of bag metadata fields and default field values to be used with each bag in a consistent way.
+Users can select a project profile when creating a bag, and that profile will determine the initial fields and values in the bag-info.txt file, and the profile used is identified by the "Profile Name" field.
 
-####Creating custom project profiles
+#### Creating custom project profiles
 User can create custom project profiles using a simple JSON-based format. When the bagger application is first started the bagger folder gets created in the user's home folder and contains some default profiles.
-Profile files should be named \<profile name>-profile.json and stored in the bagger's home directory: <user-home-dir>/bagger. 
+Profile files should be named \<profile name>-profile.json and stored in the bagger's home directory: <user-home-dir>/bagger.
 
-On Windows, it is C:\"Documents and Settings"\\<user>\bagger. On Unix-like operating system, it is ~/bagger.  Also when the bagger application is started it creates a few default profiles in the above bagger folder, which can be used as a guide to create custom profiles.
+On Windows, it is `C:\\Documents and Settings\\<user>\bagger`. On Unix-like operating system, it is ~/bagger.  Also when the bagger application is started it creates a few default profiles in the above bagger folder, which can be used as a guide to create custom profiles.
 Since [pull request #12](https://github.com/LibraryOfCongress/bagger/pull/12) you can now change where bagger looks for profiles by setting the system property `BAGGER_PROFILES_HOME`. This can be set using environment variable BAGGER_OPTS like this in bash:
 ``` bash
 export BAGGER_OPTS="-DBAGGER_PROFILES_HOME=/tmp"
@@ -50,7 +50,7 @@ export BAGGER_OPTS="-DBAGGER_PROFILES_HOME=/tmp"
 Also when using a new Bagger version please remove the bagger folder created by the previous Bagger version in the user's home folder.  
 This will insure that the new/updated profiles are created in the bagger folder after the new bagger version is started.
 
-####Profile format
+#### Profile format
 To support the use of profiles for bag-info.txt editing in the Bagger and in the various Transfer webapps, the following describes a JSON serialization of a profile:
 
 ``` python
@@ -74,7 +74,7 @@ The meanings of some field properties are explained here:
 
 The Project Profile format is subject to change in the future releases.
 
-####Ordering of fields
+#### Ordering of fields
 Since version 2.5 you can now enforce the ordering in the display of the fields. You **MUST** use the keyword `ordered`. An example:
 ```python
 {
@@ -94,7 +94,7 @@ Since version 2.5 you can now enforce the ordering in the display of the fields.
 }
 ```
 
-For a ful example see [ordered-other-project-profile.json](bagger-business/src/main/resources/gov/loc/repository/bagger/profiles/ordered-other-project-profile.json)
+For a full example see [ordered-other-project-profile.json](bagger-business/src/main/resources/gov/loc/repository/bagger/profiles/ordered-other-project-profile.json)
 
 #### Sample profile
 Here is a sample profile (please ignore the comments (//) when creating a JSON profile, it is only for explaining the fields):
@@ -132,7 +132,7 @@ The file should be named `<profile name>-profile.json`. For example, wdl-profile
 The items in the profile file (i.e. JSON file) are listed in the Bag-Info tab of Bagger.
 
 
-##Bagger Build Process
+## Bagger Build Process
 Bagger uses uses [Gradle](https://gradle.org/) for its build system. Check out their great [documentation](https://docs.gradle.org/current/userguide/userguide_single.html) to learn more.
 
 To build the Bagger application, execute the following steps from the top level folder of the distribution:
@@ -141,7 +141,7 @@ gradle distZip
 ```
 After running successfully the bagger application will be zipped and located in bagger/build/distributions/bagger.zip. Simply unzip to install anywhere.
 
-##Exceptions
+## Exceptions
 There are a few common causes for the bagger application to fail which are:
 
 i)   Incorrect version of the Java Run Time Environment or if no System Path is set for Java.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Bagger
+# Bagger
 [![License](https://img.shields.io/badge/License-Public--Domain-blue.svg)](https://github.com/LibraryOfCongress/bagger/blob/master/LICENSE.txt)
 
 ## Introduction

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ For a full example see [ordered-other-project-profile.json](bagger-business/src/
 #### Sample profile
 Here is a sample profile (please ignore the comments (//) when creating a JSON profile, it is only for explaining the fields):
 
-``` python
+```
 {
    //Source-organization is required and may have any value
    "Source-organization" : {


### PR DESCRIPTION
Fixed some of the syntax parsing so it displays better on GitHub. Some header hashes were directly against the header text without spaces leading to display issues. A few sample dirpaths and examples had formatting issues. One typo. And a JSON code block had the recommendation to parse as Python. While its comments keep it from being parsable as JSON, those comments contain restricted words from Python, leading the parsing to look wrong. Suggesting it be parsed as Python conferred no advantages.