### PR TITLE
Replace matcher.match with matcher.search

### DIFF
--- a/bagger/scripts/baggerLinter.py
+++ b/bagger/scripts/baggerLinter.py
@@ -35,7 +35,7 @@ def createModifiedManifest(manifest, regexes, *, dryrun=False):
         matcher = re.compile(regex)
         for line in original_manifest_file:
             file_entry = line.split(' ', 1)[1]
-            if matcher.match(file_entry):
+            if matcher.search(file_entry):
                 if dryrun:
                     print("Would have removed [%s] from manifest because it matches regex [%s]" % (line.rstrip(), regex))
                 else:
@@ -81,7 +81,7 @@ def updateTagmanifest(updated_manifest_hash):
 def removeMatching(regex, starting_dir, *, dryrun=False):
     for dir_name, sub_dir_list, file_list in os.walk(starting_dir):
         matcher = re.compile(regex)
-        if matcher.match(dir_name):
+        if matcher.search(dir_name):
             if dryrun:
                 print("Would have removed directory[%s] from filesystem cause it matches regex [%s]"%(dir_name, regex))
             elif os.path.islink(dir_name):
@@ -92,7 +92,7 @@ def removeMatching(regex, starting_dir, *, dryrun=False):
                 shutil.rmtree(dir_name, ignore_errors=True)
         else:
             for filename in file_list:
-                if matcher.match(filename):
+                if matcher.search(filename):
                     if dryrun:
                         print("Would have removed file [%s] from filesystem cause it matches regex [%s]" % (filename, regex))
                     elif os.path.islink(filename):


### PR DESCRIPTION
matcher.match matches only the beginning of the string, effectively changing your regex from /regex/ to /^regex/. This is undesired behavior because 1) it is unexpected because it is not matching versus the real given regex, and 2) more practically, this breaks linting of files that exist in subdirectories. E.g. a file that lives in my_bag/data/objects/my_folder/my_file.txt would not be fully linted with a regex of /my_file\.txt/ because the manifest contains the directory information, and matcher.match only looks at the beginning of the string, so the manifest does not get linted, but the file does, because the file list command only returns the filename with no path. Switching to matcher.search fixes this problem by matching anywhere in the string as expected.